### PR TITLE
Initial django 1.7 compatibility.  Replaced the USER/USER_MODEL

### DIFF
--- a/tos/models.py
+++ b/tos/models.py
@@ -3,16 +3,6 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 
-# Django 1.4 compatability
-try:
-    from django.contrib.auth import get_user_model
-except ImportError:
-    from django.contrib.auth.models import User
-    get_user_model = lambda: User
-
-
-USER_MODEL = get_user_model()
-
 
 class NoActiveTermsOfService(ValidationError):
     pass
@@ -36,6 +26,7 @@ class TermsOfServiceManager(models.Manager):
 
 class TermsOfService(BaseModel):
     active = models.BooleanField(verbose_name=_('active'),
+                                 default=False,
                                  help_text=_(u'Only one terms of service is allowed to be active'))
     content = models.TextField(verbose_name=_('content'), blank=True)
     objects = TermsOfServiceManager()
@@ -69,7 +60,7 @@ class TermsOfService(BaseModel):
 
 class UserAgreement(BaseModel):
     terms_of_service = models.ForeignKey(TermsOfService, related_name='terms')
-    user = models.ForeignKey(USER_MODEL, related_name='user_agreement')
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='user_agreement')
 
     def __unicode__(self):
         return u'%s agreed to TOS: %s' % (self.user.username,

--- a/tos/tests/test_models.py
+++ b/tos/tests/test_models.py
@@ -1,26 +1,26 @@
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from tos.models import (
-                        TermsOfService,
-                        UserAgreement,
-                        has_user_agreed_latest_tos,
-                        USER_MODEL
-                       )
+    TermsOfService,
+    UserAgreement,
+    has_user_agreed_latest_tos,
+)
 
 
 class TestModels(TestCase):
 
     def setUp(self):
-        self.user1 = USER_MODEL.objects.create_user('user1',
-                                                    'user1@example.com',
-                                                    'user1pass')
-        self.user2 = USER_MODEL.objects.create_user('user2',
-                                                    'user2@example.com',
-                                                    'user2pass')
-        self.user3 = USER_MODEL.objects.create_user('user3',
-                                                    'user3@example.com',
-                                                    'user3pass')
+        self.user1 = get_user_model().objects.create_user('user1',
+                                                          'user1@example.com',
+                                                          'user1pass')
+        self.user2 = get_user_model().objects.create_user('user2',
+                                                          'user2@example.com',
+                                                          'user2pass')
+        self.user3 = get_user_model().objects.create_user('user3',
+                                                          'user3@example.com',
+                                                          'user3pass')
 
         self.tos1 = TermsOfService.objects.create(
             content="first edition of the terms of service",

--- a/tos/tests/test_views.py
+++ b/tos/tests/test_views.py
@@ -1,21 +1,16 @@
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import TestCase
+from django.contrib.auth import get_user_model
 
-# Django 1.4 compatability
-try:
-    from django.contrib.auth import get_user_model
-except ImportError:
-    from django.contrib.auth.models import User
-    get_user_model = lambda: User
+from tos.models import TermsOfService, UserAgreement, has_user_agreed_latest_tos
 
-from tos.models import TermsOfService, UserAgreement, has_user_agreed_latest_tos, USER_MODEL as USER
 
 class TestViews(TestCase):
 
     def setUp(self):
-        self.user1 = USER.objects.create_user('user1', 'user1@example.com', 'user1pass')
-        self.user2 = USER.objects.create_user('user2', 'user2@example.com', 'user2pass')
+        self.user1 = get_user_model().objects.create_user('user1', 'user1@example.com', 'user1pass')
+        self.user2 = get_user_model().objects.create_user('user2', 'user2@example.com', 'user2pass')
 
         self.tos1 = TermsOfService.objects.create(
             content="first edition of the terms of service",


### PR DESCRIPTION
constants with calls to either settings.AUTH_USER_MODEL or
get_user_model(), as discussed in the django docs:

https://docs.djangoproject.com/en/1.7/topics/auth/customizing/#referencing-the-user-model

Update the tests to use get_user_model() directly.