### PR TITLE
Add cache middleware and check on every request

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,23 +15,139 @@ Summary
     - Users need to be informed and agree/re-agree when they login (custom login is provided)
     - Just two models (TOS and user agreement)
 
-Installation
-============
+Terms Of Service Installation
+=============================
 
  1. `pip install django-tos`
 
- 2. Add `tos` to your INSTALLED_APPS setting.
+ 2. Add `tos` to your `INSTALLED_APPS` setting.
 
- 3. Run the command `manage.py syncdb` or on newer version of Django `manage.py migrate`.
+ 3. Sync your database with `python manage.py migrate` or `python manage.py syncdb` for Django < 1.7.
 
- 4. In your root urlconf file `urls.py` add::
+Configuration
+=============
 
-     # terms of service links
-     urlpatterns += patterns('',
-         url(r'^login/$', 'tos.views.login', {}, 'auth_login',),
-         url(r'^terms-of-service/', include('tos.urls')),
-     )
+Options
+```````
 
+There are two ways to configure `django-tos` - either enable the TOS check when users sign in, or use middleware to enable the TOS check on every `GET` request.
+
+If you cannot override your login view (for instance, if you're using `django-allauth <https://django-allauth.readthedocs.io/en/latest/>`_) you should use the second option.
+
+There are some additional advantages of using the middleware option:
+
+* Allow some of your users to skip the TOS check (eg: developers, staff, admin, superusers, employees)
+* Best case for staff users: 1 cache hit
+* Best case for non-staff users: 1 cache miss, 1 cache hit
+* Uses signals to invalidate cached agreements
+* Skips the agreement check when the user is anonymous or not signed in
+* Skips the agreement check when the request is AJAX
+* Skips the agreement check when the request isn't a `GET` request (to avoid getting in the way of data mutations)
+  
+But there are some disadvantages:
+
+* Worst case: 1 cache miss, 1 database query, 1 cache set (this should only happen when the user signs in)
+* Requires a separate cache for `django-tos` because...
+* Invalidates **entire** TOS cache when `TermsOfService` is changed
+* Requires a cache key for each user who is signed in
+* Requires an additional cache key for each staff user
+
+Because of this, the middleware is 100% optional.
+
+TOS Check On Login
+``````````````````
+
+In your root urlconf file `urls.py` add::
+
+    # terms of service links
+    urlpatterns += patterns('',
+        url(r'^login/$', 'tos.views.login', {}, 'auth_login',),
+        url(r'^terms-of-service/', include('tos.urls')),
+    )
+
+Middleware Check
+````````````````
+
+1. In your root urlconf file `urls.py` only add the terms-of-service URLs::
+
+    # terms of service links
+    urlpatterns += patterns('',
+        url(r'^terms-of-service/', include('tos.urls')),
+    )
+
+2. It is strongly recommended to use a cache specifically for `django-tos`, because it clears ALL keys in the configured cache when `TermsOfService` objects change. Create a new cache in your project's `settings.py`::
+   
+       CACHES = {
+           ...
+           # The cache to use specifically for django-tos
+           'tos': {  # Can use any name
+               'BACKEND': ...,
+               'LOCATION': ...,
+               'NAME': 'tos-cache',  # Can use any name
+           },
+       }
+
+3. Configure `django-tos` to use the cache::
+
+       TOS_CACHE_NAME = 'tos'  # Much match the key name in in `CACHES`.
+
+4. Then in your project's `settings.py` add the middleware to `MIDDLEWARE_CLASSES`::
+
+    MIDDLEWARE_CLASSES = (
+        ...
+        # Terms of service checks
+        'tos.middleware.UserAgreementMiddleware',
+    )
+
+5. To allow users to skip the TOS check, you will need to set corresponding cache keys for them in the TOS cache. The cache key for each user will need to be prefixed with 'django:tos:skip_tos_check:', and have the user ID appended to it.
+
+   Here is an example app configuration that allows staff users and superusers to skip the tos check:
+
+   .. code-block:: python
+
+    from django.apps import AppConfig, apps
+    from django.conf import settings
+    from django.contrib.auth import get_user_model
+    from django.core.cache import caches
+    from django.db.models import Q
+    from django.db.models.signals import post_save, pre_save
+    from django.dispatch import receiver
+
+    class MyAppConfig(AppConfig):
+        def ready(self):
+            if 'tos' in settings.INSTALLED_APPS:
+                cache = caches[getattr(settings, 'TOS_CACHE_NAME')]
+                tos_app = apps.get_app_config('tos')
+                TermsOfService = tos_app.get_model('TermsOfService')
+
+                @receiver(post_save, sender=get_user_model(), dispatch_uid='set_staff_in_cache_for_tos')
+                def set_staff_in_cache_for_tos(user, instance, **kwargs):
+                    if kwargs.get('raw', False):
+                        return
+
+                    # If the user is staff allow them to skip the TOS agreement check
+                    if instance.is_staff or instance.is_superuser:
+                        cache.set('django:tos:skip_tos_check:{}'.format(instance.id))
+
+                    # But if they aren't make sure we invalidate them from the cache
+                    elif cache.get('django:tos:skip_tos_check:{}'.format(instance.id), False):
+                        cache.delete('django:tos:skip_tos_check:{}'.format(instance.id))
+
+                @receiver(post_save, sender=TermsOfService, dispatch_uid='add_staff_users_to_tos_cache')
+                def add_staff_users_to_tos_cache(*args, **kwargs):
+                    if kwargs.get('raw', False):
+                        return
+
+                    # Efficiently cache all of the users who are allowed to skip the TOS
+                    # agreement check
+                    cache.set_many({
+                        'django:tos:skip_tos_check:{}'.format(staff_user.id): True
+                        for staff_user in get_user_model().objects.filter(
+                            Q(is_staff=True) | Q(is_superuser=True))
+                    })
+
+                # Immediately add staff users to the cache
+                add_staff_users_to_tos_cache()
 
 ===============
 django-tos-i18n
@@ -39,8 +155,8 @@ django-tos-i18n
 
 django-tos internationalization using django-modeltranslation.
 
-Installation
-============
+Terms Of Service i18n Installation
+==================================
 
 Assuming you have correctly installed django-tos in your app you only need to
 add following apps to ``INSTALLED_APPS``::

--- a/tos/__init__.py
+++ b/tos/__init__.py
@@ -1,1 +1,3 @@
+default_app_config = 'tos.apps.TOSConfig'
+
 VERSION = (0, 6, 0)

--- a/tos/apps.py
+++ b/tos/apps.py
@@ -1,0 +1,28 @@
+from django.apps import AppConfig
+from django.conf import settings
+from django.core.cache import caches
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+
+MIDDLEWARES = getattr(settings, 'MIDDLEWARE_CLASSES', [])
+
+
+class TOSConfig(AppConfig):
+    name = 'tos'
+    verbose_name = 'Terms Of Service'
+
+    def ready(self):
+        if 'tos.middleware.UserAgreementMiddleware' in MIDDLEWARES:
+            # Force the user to create a separate cache
+            cache = caches[getattr(settings, 'TOS_CACHE_NAME')]
+
+            TermsOfService = self.get_model('TermsOfService')
+
+            @receiver(pre_save, sender=TermsOfService, dispatch_uid='invalidate_cached_agreements')
+            def invalidate_cached_agreements(TermsOfService, instance, **kwargs):
+                if kwargs.get('raw', False):
+                    return
+
+                # Efficiently clear all keys from the cache
+                cache.clear()

--- a/tos/apps.py
+++ b/tos/apps.py
@@ -15,7 +15,7 @@ class TOSConfig(AppConfig):
     def ready(self):
         if 'tos.middleware.UserAgreementMiddleware' in MIDDLEWARES:
             # Force the user to create a separate cache
-            cache = caches[getattr(settings, 'TOS_CACHE_NAME')]
+            cache = caches[getattr(settings, 'TOS_CACHE_NAME', 'default')]
 
             TermsOfService = self.get_model('TermsOfService')
 
@@ -24,5 +24,13 @@ class TOSConfig(AppConfig):
                 if kwargs.get('raw', False):
                     return
 
-                # Efficiently clear all keys from the cache
-                cache.clear()
+                # Set the key version to 0 if it doesn't exist and leave it
+                # alone if it does
+                cache.add('django:tos:key_version', 0)
+
+                # This key will be used to version the rest of the TOS keys
+                # Incrementing it will effectively invalidate all previous keys
+                cache.incr('django:tos:key_version')
+
+            # Create the TOS key version immediately
+            invalidate_cached_agreements(TermsOfService, None)

--- a/tos/compat.py
+++ b/tos/compat.py
@@ -2,6 +2,14 @@ import django
 from django.conf import settings
 
 
+def patterns(mod, *urls):
+    if mod != '' or django.VERSION < (1, 9):
+        from django.conf.urls import patterns
+        return patterns(mod, *urls)
+    else:
+        return list(urls)
+
+
 def get_fk_user_model():
     if django.VERSION >= (1, 5):
         return settings.AUTH_USER_MODEL

--- a/tos/middleware.py
+++ b/tos/middleware.py
@@ -1,0 +1,56 @@
+from django.conf import settings
+from django.contrib.auth import SESSION_KEY as session_key
+from django.core.cache import caches
+from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect
+
+from .models import UserAgreement
+
+cache = caches[getattr(settings, 'TOS_CACHE_NAME')]
+
+
+class UserAgreementMiddleware(object):
+    """
+    Some middleware to check if users have agreed to the latest TOS
+    """
+    def process_request(self, request):
+        # Don't get in the way of any mutating requests
+        if request.method != 'GET':
+            return None
+
+        # Ignore ajax requests
+        if request.is_ajax():
+            return None
+
+        # If the user doesn't have a user ID, ignore them - they're anonymous
+        if not request.session.get(session_key, None):
+            return None
+
+        # Grab the user ID from the session so we avoid hitting the database
+        # for the user object.
+        # NOTE: We use the user ID because it's not user-settable and it won't
+        #       ever change (usernames and email addresses can change)
+        user_id = request.session.get(session_key)
+
+        # Skip if the user is allowed to skip - for instance, if the user is an
+        # admin or a staff member
+        if cache.get('django:tos:skip_tos_check:{}'.format(user_id), False):
+            return None
+
+        # Ping the cache for the user agreement
+        user_agreed = cache.get('django:tos:agreed:{}'.format(user_id), None)
+
+        # If the cache is missing this user
+        if user_agreed is None:
+            # Grab the data from the database
+            user_agreed = UserAgreement.objects.filter(
+                user__id=user_id,
+                terms_of_service__active=True).exists()
+
+            # Set the value in the cache
+            cache.set('django:tos:agreed:{}'.format(user_id), user_agreed)
+
+        if not user_agreed:
+            return HttpResponseRedirect('tos_check_tos')
+
+        return None

--- a/tos/middleware.py
+++ b/tos/middleware.py
@@ -60,7 +60,6 @@ class UserAgreementMiddleware(object):
             cache.set('django:tos:agreed:{}'.format(user_id), user_agreed, version=key_version)
 
         if not user_agreed:
-            print("User didn't agree")
             return add_never_cache_headers(HttpResponseRedirect(tos_check_url))
 
         return None

--- a/tos/urls.py
+++ b/tos/urls.py
@@ -1,5 +1,8 @@
-from django.conf.urls import url, patterns
+from django.conf.urls import url
+
+from tos.compat import patterns
 from tos.views import check_tos, TosView
+
 
 urlpatterns = patterns('',
     # Terms of Service conform


### PR DESCRIPTION
Overriding the login view doesn't work for all use cases. Also if you have particularly long-lived sessions, signed in users may be able to use your site for days/weeks/months after you change your TOS without agreeing to the new one.

This adds optional middleware that uses a configured cache to check for TOS agreement on every GET request.

Advantages
----------

* Is 100% optional
* Get Django >= 1.9 support for free! (`apps.AppConfig`)
* Allows sites to allow users to skip TOS check (admins, staff, etc.) by setting cache keys (see example below)
* Uses `request.session` to get user ID without querying database
* Cache keys use user ID instead of username or email because the user ID will never change
* Uses signals to invalidate cached agreements
* Uses Django's built-in [cache versioning](https://docs.djangoproject.com/en/1.9/topics/cache/#cache-versioning) to invalidate cache keys

Disadvantages
-------------

* Requires a cache key for all users and (optionally) additional keys for all staff users
* Doesn't clear out old versions of cache keys
* ~~Requires a named cache specifically for `tos` because...~~ Not anymore!
* ~~Invalidates **ALL** keys in cache when `TermsOfService` is saved~~ Not anymore!
* Hasn't been used in production yet
* ~~I haven't written documentation~~ Done!
* I haven't written tests for this code yet

Efficiency
----------

* Best case for staff users: 2 cache hits
* Best case for non-staff users: 1 cache miss, 2 cache hits
* Worst case: 1 cache hit, 1 cache miss, a database query, 1 cache set

Notes
-----

We prefix our cache keys manually (with `django:tos:`) because we don't want to step on other apps' cache keys if it's configured to use a common cache. I'm kind of surprised Django doesn't have a way to do this on a per-app basis.

Example
-------

This is how a site could allow staff users and superusers to skip the TOS check.
```python
from django.apps import AppConfig, apps
from django.conf import settings
from django.contrib.auth import get_user_model
from django.core.cache import caches
from django.db.models import Q
from django.db.models.signals import post_save, pre_save
from django.dispatch import receiver


class MyAppConfig(AppConfig):
    def ready(self):
        if 'tos' in settings.INSTALLED_APPS:
            cache = caches[getattr(settings, 'TOS_CACHE_NAME', 'default')]
            tos_app = apps.get_app_config('tos')
            TermsOfService = tos_app.get_model('TermsOfService')

            @receiver(post_save, sender=get_user_model(), dispatch_uid='set_staff_in_cache_for_tos')
            def set_staff_in_cache_for_tos(user, instance, **kwargs):
                if kwargs.get('raw', False):
                    return

                # Get the cache prefix
                key_version = cache.get('django:tos:key_version')

                # If the user is staff allow them to skip the TOS agreement check
                if instance.is_staff or instance.is_superuser:
                    cache.set('django:tos:skip_tos_check:{}'.format(instance.id), version=key_version)

                # But if they aren't make sure we invalidate them from the cache
                elif cache.get('django:tos:skip_tos_check:{}'.format(instance.id), False):
                    cache.delete('django:tos:skip_tos_check:{}'.format(instance.id), version=key_version)

            @receiver(post_save, sender=TermsOfService, dispatch_uid='add_staff_users_to_tos_cache')
            def add_staff_users_to_tos_cache(*args, **kwargs):
                if kwargs.get('raw', False):
                    return

                # Get the cache prefix
                key_version = cache.get('django:tos:key_version')

                # Efficiently cache all of the users who are allowed to skip the TOS
                # agreement check
                cache.set_many({
                    'django:tos:skip_tos_check:{}'.format(staff_user.id): True
                    for staff_user in get_user_model().objects.filter(
                        Q(is_staff=True) | Q(is_superuser=True))
                }, version=key_version)

            add_staff_users_to_tos_cache(TermsOfService, None)
