### PR TITLE
Add option/fix for user models with UUIDs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,13 +124,6 @@ Option 2 Configuration
 
    this setting defaults to the ``default`` cache.
 
-   If the primary keys on your user models are UUIDs, you will need to set the
-   ``TOS_ID_FUNC`` to ``str`` or ``uuid.UUID`` as well:
-
-   .. code-block:: python
-
-       TOS_ID_FUNC = str  # No quotes
-
 4. Then in your project's ``settings.py`` add the middleware to ``MIDDLEWARE_CLASSES``:
 
    .. code-block:: python

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,13 @@ Option 2 Configuration
 
    this setting defaults to the ``default`` cache.
 
+   If the primary keys on your user models are UUIDs, you will need to set the
+   ``TOS_ID_FUNC`` to ``str`` or ``uuid.UUID`` as well:
+
+   .. code-block:: python
+
+       TOS_ID_FUNC = str  # No quotes
+
 4. Then in your project's ``settings.py`` add the middleware to ``MIDDLEWARE_CLASSES``:
 
    .. code-block:: python

--- a/tos/middleware.py
+++ b/tos/middleware.py
@@ -9,6 +9,8 @@ from django.utils.cache import add_never_cache_headers
 from .compat import get_cache
 from .models import UserAgreement
 
+# Set to str or uuid.UUID for UUIDs
+tos_id_func = getattr(settings, 'TOS_ID_FUNC', int)
 cache = get_cache(getattr(settings, 'TOS_CACHE_NAME', 'default'))
 tos_check_url = reverse('tos_check_tos')
 
@@ -38,7 +40,7 @@ class UserAgreementMiddleware(deprecation.MiddlewareMixin if DJANGO_VERSION >= (
         # for the user object.
         # NOTE: We use the user ID because it's not user-settable and it won't
         #       ever change (usernames and email addresses can change)
-        user_id = int(request.session['_auth_user_id'])
+        user_id = tos_id_func(request.session['_auth_user_id'])
         user_auth_backend = request.session['_auth_user_backend']
 
         # Get the cache prefix

--- a/tos/middleware.py
+++ b/tos/middleware.py
@@ -9,8 +9,6 @@ from django.utils.cache import add_never_cache_headers
 from .compat import get_cache
 from .models import UserAgreement
 
-# Set to str or uuid.UUID for UUIDs
-tos_id_func = getattr(settings, 'TOS_ID_FUNC', int)
 cache = get_cache(getattr(settings, 'TOS_CACHE_NAME', 'default'))
 tos_check_url = reverse('tos_check_tos')
 
@@ -40,7 +38,7 @@ class UserAgreementMiddleware(deprecation.MiddlewareMixin if DJANGO_VERSION >= (
         # for the user object.
         # NOTE: We use the user ID because it's not user-settable and it won't
         #       ever change (usernames and email addresses can change)
-        user_id = tos_id_func(request.session['_auth_user_id'])
+        user_id = request.session['_auth_user_id']
         user_auth_backend = request.session['_auth_user_backend']
 
         # Get the cache prefix


### PR DESCRIPTION
This [line](https://github.com/revsys/django-tos/commit/0b48ae39382cc5fff18a6d53a931cdf65506f99c#diff-923c9f6aabadaa2ccc593cab206f4509R41) from 0b48ae39382cc5fff18a6d53a931cdf65506f99c assumes that all IDs on the user model will be convertible to integers, which isn't the case for UUIDs.

I add a new option: `TOS_ID_FUNC` that is the callable to use to convert user IDs, and have it default to `int` for backwards (and very common) compatibility. Developers who have UUIDs on their user models can specify either `str` or `uuid.UUID` as the conversion function.