### PR TITLE
More small stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 .coverage
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - DJANGO="Django>=1.8,<1.9"
   - DJANGO="Django>=1.9,<1.10"
   - DJANGO="Django>=1.10,<1.11"
+  - DJANGO="Django>=1.11,<2.0"
 matrix:
   exclude:
     # Python 2.6 support has been dropped in Django 1.7
@@ -29,6 +30,8 @@ matrix:
       env: DJANGO="Django>=1.9,<1.10"
     - python: "2.6"
       env: DJANGO="Django>=1.10,<1.11"
+    - python: "2.6"
+      env: DJANGO="Django>=1.11,<2.0"
     - python: "3.4"
       env: DJANGO="Django>=1.4,<1.5"
     - python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,14 @@ python:
   - "3.5"
   - "3.6"
 install:
-  - pip install coverage
+  - pip install coveralls coverage
   - pip install $DJANGO
 script:
   - coverage run runtests.py
   - coverage report -m
+after_script:
+  - coverage combine
+  - coveralls
 env:
   - DJANGO="Django>=1.4,<1.5"
   - DJANGO="Django>=1.5,<1.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
   - DJANGO="Django>=1.9,<1.10"
   - DJANGO="Django>=1.10,<1.11"
   - DJANGO="Django>=1.11,<2.0"
+  - DJANGO="https://github.com/django/django/archive/master.tar.gz"
 matrix:
   exclude:
     # Python 2.6 support has been dropped in Django 1.7
@@ -33,8 +34,14 @@ matrix:
       env: DJANGO="Django>=1.10,<1.11"
     - python: "2.6"
       env: DJANGO="Django>=1.11,<2.0"
+    - python: "2.6"
+      env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+    - python: "2.7"
+      env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
     - python: "3.4"
       env: DJANGO="Django>=1.4,<1.5"
+    - python: "3.4"
+      env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
     - python: "3.5"
       env: DJANGO="Django>=1.4,<1.5"
     - python: "3.5"
@@ -57,3 +64,5 @@ matrix:
       env: DJANGO="Django>=1.9,<1.10"
     - python: "3.6"
       env: DJANGO="Django>=1.10,<1.11"
+  allow_failures:
+    - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
   - pip install coverage
   - pip install $DJANGO
@@ -42,3 +43,17 @@ matrix:
       env: DJANGO="Django>=1.6,<1.7"
     - python: "3.5"
       env: DJANGO="Django>=1.7,<1.8"
+    - python: "3.6"
+      env: DJANGO="Django>=1.4,<1.5"
+    - python: "3.6"
+      env: DJANGO="Django>=1.5,<1.6"
+    - python: "3.6"
+      env: DJANGO="Django>=1.6,<1.7"
+    - python: "3.6"
+      env: DJANGO="Django>=1.7,<1.8"
+    - python: "3.6"
+      env: DJANGO="Django>=1.8,<1.9"
+    - python: "3.6"
+      env: DJANGO="Django>=1.9,<1.10"
+    - python: "3.6"
+      env: DJANGO="Django>=1.10,<1.11"


### PR DESCRIPTION
* Ignore `htmlcov/` from coverage results
* Add Django 1.11 to Travis config
* Add Python 3.6 to Travis config
* Add Django master branch to Travis config (allowed to fail)
* Add coveralls to Travis config to keep track of coverage