### PR TITLE
Evict agreement from cache when user posts

### DIFF
--- a/tos/middleware.py
+++ b/tos/middleware.py
@@ -59,8 +59,9 @@ class UserAgreementMiddleware(middleware_mixin):
                 user__id=user_id,
                 terms_of_service__active=True).exists()
 
-            # Set the value in the cache
-            cache.set('django:tos:agreed:{0}'.format(user_id), user_agreed, version=key_version)
+            # Set the value in the cache if True
+            if user_agreed:
+                cache.set('django:tos:agreed:{0}'.format(user_id), user_agreed, version=key_version)
 
         if not user_agreed:
             # Confirm view uses these session keys. Non-middleware flow sets them in login view,

--- a/tos/views.py
+++ b/tos/views.py
@@ -15,7 +15,7 @@ from django.views.decorators.csrf import csrf_protect
 from django.views.generic import TemplateView
 from django.utils.translation import ugettext_lazy as _
 
-from tos.compat import get_runtime_user_model, get_request_site
+from tos.compat import get_cache, get_runtime_user_model, get_request_site
 from tos.models import has_user_agreed_latest_tos, TermsOfService, UserAgreement
 
 
@@ -108,6 +108,10 @@ def login(request, template_name='registration/login.html',
 
                 # Log the user in.
                 auth_login(request, user)
+
+                # Evict a cached acceptance record to force a fetch
+                cache = get_cache(getattr(settings, 'TOS_CACHE_NAME', 'default'))
+                cache.delete('django:tos:agreed:{0}'.format(user_id))
 
                 if request.session.test_cookie_worked():
                     request.session.delete_test_cookie()


### PR DESCRIPTION
When using TOS middleware, the cache will first be populated with a `False` acceptance the first time a non-accepting user accesses a page. Once they have confirmed however, the cache entry for "False" acceptance is still present, which will cause a redirect loop until the cache item expires.

This patch will evict the user's cache record when acceptance is recorded, forcing a database fetch on the next request.