### PR TITLE
Refactor to betterize integrations

### DIFF
--- a/tos/middleware.py
+++ b/tos/middleware.py
@@ -51,11 +51,11 @@ class UserAgreementMiddleware(MiddlewareMixin):
 
         # Skip if the user is allowed to skip - for instance, if the user is an
         # admin or a staff member
-        if cache.get('django:tos:skip_tos_check:{0}'.format(str(user_id)), False, version=key_version):
+        if cache.get(f'django:tos:skip_tos_check:{user_id}', False, version=key_version):
             return None
 
         # Ping the cache for the user agreement
-        user_agreed = cache.get('django:tos:agreed:{0}'.format(str(user_id)), None, version=key_version)
+        user_agreed = cache.get(f'django:tos:agreed:{user_id}', None, version=key_version)
 
         # If the cache is missing this user
         if user_agreed is None:
@@ -65,7 +65,7 @@ class UserAgreementMiddleware(MiddlewareMixin):
                 terms_of_service__active=True).exists()
 
             # Set the value in the cache
-            cache.set('django:tos:agreed:{0}'.format(user_id), user_agreed, version=key_version)
+            cache.set(f'django:tos:agreed:{user_id}', user_agreed, version=key_version)
 
         if not user_agreed:
             # Confirm view uses these session keys. Non-middleware flow sets them in login view,


### PR DESCRIPTION
When running with the TOS middleware configured, this package interferes with [django-guest-user](/julianwachholz/django-guest-user/), since that package auto-creates users, but doesn't (and really can't) create users that have already agreed to the TOS. So guest users, instead of being able to use the site without (explicitly) logging in, have to first agree to the TOS, which is...odd.

This PR simply modernizes and refactors the django-tos middleware a bit to make it easier for django-guest-user to either include instructions on how to create a custom TOS middleware or to distribute a contrib module in that package.

Specifically, with this refactoring, I believe properly checking for guest users in a custom middleware should be this easy:

```python
from tos.middleware import UserAgreementMiddleware
from guest_user.functions import is_guest_user

class GuestUserAgreementMiddleware(UserAgreementMiddleware):
    def should_fast_skip(self, request):
        if super().should_fast_skip(request):
            return True
        return is_guest_user(request.user)
```

Which I think is rather spiffy.