### PR TITLE
Fix signal handler

### DIFF
--- a/tos/apps.py
+++ b/tos/apps.py
@@ -19,4 +19,4 @@ class TOSConfig(AppConfig):
                              dispatch_uid='invalidate_cached_agreements')
 
             # Create the TOS key version immediately
-            invalidate_cached_agreements(TermsOfService, None)
+            invalidate_cached_agreements(TermsOfService)

--- a/tos/signal_handlers.py
+++ b/tos/signal_handlers.py
@@ -6,7 +6,7 @@ from django.core.cache import caches
 cache = caches[getattr(settings, 'TOS_CACHE_NAME', 'default')]
 
 
-def invalidate_cached_agreements(TermsOfService, instance, **kwargs):
+def invalidate_cached_agreements(sender, **kwargs):
     if kwargs.get('raw', False):
         return
 

--- a/tos/tests/test_middleware.py
+++ b/tos/tests/test_middleware.py
@@ -167,14 +167,14 @@ class BumpCoverage(TestCase):
     def test_invalidate_cached_agreements(self):
         cache = caches[getattr(settings, 'TOS_CACHE_NAME', 'default')]
 
-        invalidate_cached_agreements(TermsOfService, {})
+        invalidate_cached_agreements(TermsOfService)
 
         key_version = cache.get('django:tos:key_version')
 
-        invalidate_cached_agreements(TermsOfService, {})
+        invalidate_cached_agreements(TermsOfService)
 
         self.assertEqual(cache.get('django:tos:key_version'), key_version+1)
 
-        invalidate_cached_agreements(TermsOfService, {}, raw=True)
+        invalidate_cached_agreements(TermsOfService, raw=True)
 
         self.assertEqual(cache.get('django:tos:key_version'), key_version+1)


### PR DESCRIPTION
Quick fix for the signal handler. [Signal handlers only need `sender` and `**kwargs` arguments](https://docs.djangoproject.com/en/4.1/topics/signals/#receiver-functions):

```python
def my_callback(sender, **kwargs):
    print("Request finished!")
```