### PR TITLE
Added Django 4.1 & 4.2 compatibility

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -26,6 +26,12 @@ jobs:
           - python-version: "3.8"
             django-version: Django==4.0
 
+          - python-version: "3.8"
+            django-version: Django==4.1
+
+          - python-version: "3.8"
+            django-version: Django==4.2
+
           - python-version: "3.9"
             django-version: Django==2.2
 
@@ -35,11 +41,29 @@ jobs:
           - python-version: "3.9"
             django-version: Django==4.0
 
+          - python-version: "3.9"
+            django-version: Django==3.1
+
+          - python-version: "3.9"
+            django-version: Django==4.2
+
           - python-version: "3.10"
             django-version: Django==3.2
 
           - python-version: "3.10"
             django-version: Django==4.0
+
+          - python-version: "3.10"
+            django-version: Django==3.1
+
+          - python-version: "3.10"
+            django-version: Django==4.2
+
+          - python-version: "3.11"
+            django-version: Django==4.1
+
+          - python-version: "3.11"
+            django-version: Django==4.2
 
     steps:
     - uses: actions/checkout@v2

--- a/tos/views.py
+++ b/tos/views.py
@@ -1,14 +1,12 @@
 import re
 
-from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import login as auth_login
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import AuthenticationForm
-from django.contrib.sites.models import Site
-from django.contrib.sites.requests import RequestSite
+from django.contrib.sites.shortcuts import get_current_site
 from django.core.cache import caches
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
@@ -136,10 +134,7 @@ def login(request, template_name='registration/login.html',
 
     request.session.set_test_cookie()
 
-    if Site._meta.installed:
-        current_site = Site.objects.get_current()
-    else:
-        current_site = RequestSite(request)
+    current_site = get_current_site(request)
 
     context = {
         'form': form,


### PR DESCRIPTION
This PR aims to improve the `UserAgreementMiddleware` class to better support the "new" middleware format by additionally implementing the `__call__` method. It also replaces a call to `Site._meta.installed` with `current_site = get_current_site(request)` in views.py which makes it compatible to Django 4.1 & 4.2.

The PR additionally adds a new workflow_dispatch event and Python version 3.11 as well as Django 4.1 & 4.2 to the job matrix of the GitHub workflow.

Changes:

- Modified .github/workflows/django.yml
- Modified tos/middleware.py
- Modified tos/views.py

Please review and merge this pull request if it looks good to you.