### PR TITLE
Add support for Django 4.1 and 4.2

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -27,6 +28,9 @@ jobs:
             django-version: Django==4.0
 
           - python-version: "3.8"
+            django-version: Django==4.1
+
+          - python-version: "3.8"
             django-version: Django==4.2
 
           - python-version: "3.9"
@@ -39,6 +43,9 @@ jobs:
             django-version: Django==4.0
 
           - python-version: "3.9"
+            django-version: Django==4.1
+
+          - python-version: "3.9"
             django-version: Django==4.2
 
           - python-version: "3.10"
@@ -48,7 +55,13 @@ jobs:
             django-version: Django==4.0
 
           - python-version: "3.10"
+            django-version: Django==4.1
+
+          - python-version: "3.10"
             django-version: Django==4.2
+
+          - python-version: "3.11"
+            django-version: Django==3.1
 
           - python-version: "3.11"
             django-version: Django==4.2

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -61,7 +61,7 @@ jobs:
             django-version: Django==4.2
 
           - python-version: "3.11"
-            django-version: Django==3.1
+            django-version: Django==4.1
 
           - python-version: "3.11"
             django-version: Django==4.2

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -26,6 +26,9 @@ jobs:
           - python-version: "3.8"
             django-version: Django==4.0
 
+          - python-version: "3.8"
+            django-version: Django==4.2
+
           - python-version: "3.9"
             django-version: Django==2.2
 
@@ -35,11 +38,20 @@ jobs:
           - python-version: "3.9"
             django-version: Django==4.0
 
+          - python-version: "3.9"
+            django-version: Django==4.2
+
           - python-version: "3.10"
             django-version: Django==3.2
 
           - python-version: "3.10"
             django-version: Django==4.0
+
+          - python-version: "3.10"
+            django-version: Django==4.2
+
+          - python-version: "3.11"
+            django-version: Django==4.2
 
     steps:
     - uses: actions/checkout@v2

--- a/tos/middleware.py
+++ b/tos/middleware.py
@@ -19,8 +19,8 @@ class UserAgreementMiddleware(MiddlewareMixin):
     Some middleware to check if users have agreed to the latest TOS
     """
 
-    def __init__(self, get_response=None):
-        self.get_response = get_response
+    def __init__(self, get_response):
+        super().__init__(get_response)
 
     def process_request(self, request):
         if self.should_fast_skip(request):

--- a/tos/middleware.py
+++ b/tos/middleware.py
@@ -1,3 +1,4 @@
+from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.contrib.auth import SESSION_KEY as session_key
 from django.contrib.auth import REDIRECT_FIELD_NAME
@@ -19,8 +20,13 @@ class UserAgreementMiddleware(MiddlewareMixin):
     Some middleware to check if users have agreed to the latest TOS
     """
 
-    def __init__(self, get_response):
-        super().__init__(get_response)
+    def __init__(self, get_response = None):
+        if DJANGO_VERSION < (4,0):
+            self.get_response = get_response
+        else:
+            if get_response is None:
+                raise TypeError('get_response cannot be None in Django 4.0 and later')
+            super().__init__(get_response)
 
     def process_request(self, request):
         if self.should_fast_skip(request):

--- a/tos/tests/test_middleware.py
+++ b/tos/tests/test_middleware.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME, get_user_model
 from django.core.cache import caches
+from django.http import HttpResponse
 from django.test import TestCase
 from django.test.utils import modify_settings
 from django.urls import reverse
@@ -146,7 +147,7 @@ class BumpCoverage(TestCase):
             def is_ajax(self):
                 return True
 
-        mw = UserAgreementMiddleware()
+        mw = UserAgreementMiddleware(HttpResponse())
 
         response = mw.process_request(Request())
 

--- a/tos/views.py
+++ b/tos/views.py
@@ -1,14 +1,12 @@
 import re
 
-from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import login as auth_login
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import AuthenticationForm
-from django.contrib.sites.models import Site
-from django.contrib.sites.requests import RequestSite
+from django.contrib.sites.shortcuts import get_current_site
 from django.core.cache import caches
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
@@ -136,10 +134,7 @@ def login(request, template_name='registration/login.html',
 
     request.session.set_test_cookie()
 
-    if Site._meta.installed:
-        current_site = Site.objects.get_current()
-    else:
-        current_site = RequestSite(request)
+    current_site = get_current_site(request)
 
     context = {
         'form': form,


### PR DESCRIPTION
So, now I got it all together, here are the changes I implemented for supporting Django 4.1 and 4.2:

Changes:
- Add Django 4.1 and 4.2 to test matrix in GitHub workflow
- Add Python 3.11 to test matrix in GitHub workflow
- Add possibility to manually run GitHub workflow
- Refactor `UserAgreementMiddleware` to use parent constructor and update test
- `get_response` is now a required argument in the `UserAgreementMiddleware` constructor
- Update views.py to use get_current_site

Thanks for reviewing