### PR TITLE
README.rst: Fix typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -231,7 +231,7 @@ How to migrate tos with South
 `````````````````````````````
 
 Here is some step-by-step example how to convert your legacy django-tos
-instalation synced using syncdb into a translated django-tos-i18n with South
+installation synced using syncdb into a translated django-tos-i18n with South
 migrations.
 
 1. Inform South that you want to store migrations in custom place by putting

--- a/tos/tests/test_middleware.py
+++ b/tos/tests/test_middleware.py
@@ -69,7 +69,7 @@ class TestMiddleware(TestCase):
 
     def test_invalidate_cache_on_accept_fix_redirect_loop(self):
         """
-        Make sure accepting doesnt send you right back to tos page.
+        Make sure accepting doesn't send you right back to tos page.
         """
         self.assertFalse(UserAgreement.objects.filter(terms_of_service=self.tos1, user=self.user2).exists())
 

--- a/tos/tests/test_views.py
+++ b/tos/tests/test_views.py
@@ -92,7 +92,7 @@ class TestViews(TestCase):
         self.assertIn(settings.LOGIN_REDIRECT_URL, response.url)
 
     def test_need_to_log_in(self):
-        """ GET to login url shows login tempalte."""
+        """ GET to login url shows login template."""
 
         response = self.client.get(self.login_url)
         self.assertContains(response, "Dummy login template.")

--- a/tos/views.py
+++ b/tos/views.py
@@ -118,7 +118,7 @@ def login(request, template_name='registration/login.html',
 
                 request.session['tos_user'] = user.pk
                 # Pass the used backend as well since django will require it
-                # and it can only be optained by calling authenticate, but we
+                # and it can only be obtained by calling authenticate, but we
                 # got no credentials in check_tos.
                 # see: https://docs.djangoproject.com/en/1.6/topics/auth/default/#how-to-log-a-user-in
                 request.session['tos_backend'] = user.backend


### PR DESCRIPTION
% `pipx run codespell`
```
./README.rst:234: instalation ==> installation
./tos/views.py:121: optained ==> obtained
./tos/tests/test_views.py:95: tempalte ==> template
./tos/tests/test_middleware.py:72: doesnt ==> doesn't, does not
```