### PR TITLE
GitHub Actions: Add Django v5.0 and Python 3.12 to the testing

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -60,11 +60,23 @@ jobs:
           - python-version: "3.10"
             django-version: Django==4.2
 
+          - python-version: "3.10"
+            django-version: Django==5.0
+
           - python-version: "3.11"
             django-version: Django==4.1
 
           - python-version: "3.11"
             django-version: Django==4.2
+
+          - python-version: "3.11"
+            django-version: Django==5.0
+
+          - python-version: "3.12"
+            django-version: Django==4.2
+
+          - python-version: "3.12"
+            django-version: Django==5.0
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
https://pypi.org/project/Django

https://www.djangoproject.com/weblog/2023/dec/04/django-50-released

Django 4.1 has reached the end of extended support. The final security release ([4.1.13](https://docs.djangoproject.com/en/stable/releases/4.1.13/)) was issued on November 1st. All Django 4.1 users are encouraged to [upgrade](https://docs.djangoproject.com/en/dev/howto/upgrade-version/) to Django 4.2 or later.

https://docs.djangoproject.com/en/5.0/releases/5.0
> Django 5.0 supports Python 3.10, 3.11, and 3.12.