### PR TITLE
Small cleanup

### DIFF
--- a/tos/templatetags/compat.py
+++ b/tos/templatetags/compat.py
@@ -1,1 +1,0 @@
-from django.template.defaulttags import url

--- a/tos/tests/__init__.py
+++ b/tos/tests/__init__.py
@@ -1,5 +1,0 @@
-import django
-
-if django.VERSION < (1, 6):
-    from tos.tests.test_models import *
-    from tos.tests.test_views import *


### PR DESCRIPTION
Remove a compatibility shim for [Django 1.5](https://github.com/revsys/django-tos/commit/09a71c69d73f6f60da67ebc381a8726a9a91bc84#diff-f5c02f4e4f0e786cba59fd4b75fe8cde8be02d2cfbd35ac5290c145bc57b04a7L79), and another for Django 1.6. Those versions of Django are so old, nobody should be using them anymore.

It should also be noted that we removed any internal use of these two years ago in #59.