### PR TITLE
Convert middleware to modern Django conventions and add tests

### DIFF
--- a/tos/middleware.py
+++ b/tos/middleware.py
@@ -6,7 +6,6 @@ from django.core.cache import caches
 from django.http import HttpResponseRedirect
 from django.urls import reverse_lazy
 from django.utils.cache import add_never_cache_headers
-from django.utils.deprecation import MiddlewareMixin
 
 from .models import UserAgreement
 
@@ -15,22 +14,16 @@ cache = caches[getattr(settings, 'TOS_CACHE_NAME', 'default')]
 tos_check_url = reverse_lazy('tos_check_tos')
 
 
-class UserAgreementMiddleware(MiddlewareMixin):
+class UserAgreementMiddleware:
     """
     Some middleware to check if users have agreed to the latest TOS
     """
+    def __init__(self, get_response):
+        self.get_response = get_response
 
-    def __init__(self, get_response = None):
-        if DJANGO_VERSION < (4,0):
-            self.get_response = get_response
-        else:
-            if get_response is None:
-                raise TypeError('get_response cannot be None in Django 4.0 and later')
-            super().__init__(get_response)
-
-    def process_request(self, request):
+    def __call__(self, request):
         if self.should_fast_skip(request):
-            return None
+            return self.get_response(request)
 
         # Grab the user ID from the session so we avoid hitting the database
         # for the user object.
@@ -44,7 +37,7 @@ class UserAgreementMiddleware(MiddlewareMixin):
         # Skip if the user is allowed to skip - for instance, if the user is an
         # admin or a staff member
         if cache.get(f'django:tos:skip_tos_check:{user_id}', False, version=key_version):
-            return None
+            return self.get_response(request)
 
         # Ping the cache for the user agreement
         user_agreed = cache.get(f'django:tos:agreed:{user_id}', None, version=key_version)
@@ -68,7 +61,7 @@ class UserAgreementMiddleware(MiddlewareMixin):
             add_never_cache_headers(response)
             return response
 
-        return None
+        return self.get_response(request)
 
     def should_fast_skip(self, request):
         '''Check if we should skip TOS checks without hitting the cache or database'''


### PR DESCRIPTION
Update the middleware to reflect modern django conventions.

See the "SimpleMiddleware" example on [this page](https://docs.djangoproject.com/en/5.2/topics/http/middleware/) for more information.