### PR TITLE
Add release and publish GHA workflows

### DIFF
--- a/.github/RELEASE-TEMPLATE.md
+++ b/.github/RELEASE-TEMPLATE.md
@@ -1,0 +1,4 @@
+# Announcements
+* First announcement
+
+# Changes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: PyPI Publish
+
+on:
+  release:
+    types:
+      - published
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_SYSTEM_PYTHON: 1
+
+jobs:
+  publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi-release
+      url: https://pypi.org/p/django-tos
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Add version to environment vars
+        run: |
+          PROJECT_VERSION=$(python3 -c 'import importlib.metadata; print(importlib.metadata.version("django-tos"))')
+          echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
+      - name: Restore distribution files cache
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            dist/django_tos-${{ env.PROJECT_VERSION }}-py3-none-any.whl
+            dist/django_tos-${{ env.PROJECT_VERSION }}.tar.gz
+          key: build-distributions-${{ env.PROJECT_VERSION }}
+      - name: List distribution files
+        run: |
+          ls -l dist/*.whl dist/*.tar.gz
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          print-hash: true
+          verbose: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Create release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  PYTHON_VERSION: "3.13"
+
+jobs:
+  release:
+    name: Create release
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ env.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Add version to environment vars
+        run: |
+          PROJECT_VERSION=$(python3 -c 'import importlib.metadata; print(importlib.metadata.version("django-tos"))')
+          echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
+      - name: Check if tag version matches project version
+        run: |
+          TAG=$(git describe HEAD --tags --abbrev=0)
+          echo "TAG: $TAG"
+          echo "PROJECT_VERSION: $PROJECT_VERSION"
+          if [[ "$TAG" != "v$PROJECT_VERSION" ]]; then exit 1; fi
+      - name: Install packages
+        run: |
+          python3 -m pip install --root-user-action=ignore build 'validate-pyproject[all]'
+      - name: Check pyproject.toml validity
+        # https://github.com/astral-sh/uv/issues/9653#issuecomment-3591888192
+        run: validate-pyproject ./pyproject.toml
+      - name: Build
+        run: |
+          python3 -m build
+          echo "PROJECT_VERSION: $PROJECT_VERSION"
+      - name: Release Notes
+        run: |
+          if (git describe HEAD~ --tags --abbrev=0); then
+            git log $(git describe HEAD~ --tags --abbrev=0)..HEAD --pretty='format:* %h %s (@%an)' --no-merges >> ".github/RELEASE-TEMPLATE.md"
+          else
+            touch .github/RELEASE-TEMPLATE.md
+          fi
+      - name: Create Release Draft
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: ".github/RELEASE-TEMPLATE.md"
+          draft: true
+          fail_on_unmatched_files: true
+          files: |
+            dist/django_tos-${{ env.PROJECT_VERSION }}-py3-none-any.whl
+            dist/django_tos-${{ env.PROJECT_VERSION }}.tar.gz
+      # Save build artifacts so the publish workflow doesn't need to rebuild them
+      - name: Save distribution files
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            dist/django_tos-${{ env.PROJECT_VERSION }}-py3-none-any.whl
+            dist/django_tos-${{ env.PROJECT_VERSION }}.tar.gz
+          key: build-distributions-${{ env.PROJECT_VERSION }}


### PR DESCRIPTION
Add two more GHA workflows to handle building the release distributions and publishing them to GitHub and PyPI.

This makes it MUCH easier to build and publish packages straight from GitHub. It is also arguably more secure, since it utilizes PyPI's [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) method. That alleviates project maintainers from having to generate and secure long-lived API keys. Those API keys then become [prime targets for exfiltration via malware](https://about.gitlab.com/blog/gitlab-discovers-widespread-npm-supply-chain-attack/). Using GHA WFs to publish releases is more secure and auditable.

This makes it much easier for maintainers to release new versions than relying on a single (or few) trusted project admin or owner. IMO, trusting maintainers to publish packages via pushing tags is not any more of a security risk than letting them maintain the codebase to begin with, so this doesn't require any additional trust in project maintainers than normal. Usually projects have a bottleneck of people who have permissions to release new versions to PyPI, and this alleviates that bottleneck.

With this PR, the developer experience goes like this:

* Normal PRs run the tests in `django.yml`
* Developer pushes a tag that starts with `v` -> release workflow in `release.yml` is run
  - If the pushed tag matches the current version of the package in `pyproject.toml` then:
    + the project is built into wheel and source distributions
    + an ephemeral draft changelog is automatically created from the commits
    + the `softprops/action-gh-release` GHA is run, which creates a **draft** release on GitHub with the two distribution files attached
    + the two distributions are explicitly cached to GitHub
  - If the pushed tag does not match, nothing is run
* Developer goes to GitHub, tweaks the draft release announcement to their liking, and hits publish (this officially publishes the release on GitHub) -> publish workflow in `publish.yml` is run
  - The distribution files are pulled from GitHub's cache and listed to the log for the sake of auditing
  - The distribution files are published to PyPA using their official `pypa/gh-action-pypi-publish` GHA

A few things to note:
1. I use tags to identify the version of GHAs to run. Those tags are not necessarily immutable. Using Git hashes would be slightly more secure, with the tradeoff that it wouldn't be immediately apparent what versions the tags referred to, making it more difficult to upgrade them in the future.
2. GitHub allows project admins to create an allowlist of GHAs that can be added to workflows. I highly recommend using this.

Relevant links:
* https://github.com/softprops/action-gh-release
* https://blog.kubesimplify.com/automated-github-releases-with-github-actions-and-conventional-commits
* https://github.com/pypa/gh-action-pypi-publish
* https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
* https://github.com/blag/django-bigredbutton/tree/main/.github/workflows/ (this PR was copied and tweaked from those files)