### PR TITLE
Fix version drift between tos/__init__.py and pyproject (1.1.0 -> 1.2.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ push = false
 
 [tool.bumpver.file_patterns]
 "pyproject.toml" = ['current_version = "{version}"', 'version = "{version}"']
+"tos/__init__.py" = ['__version__ = "{version}"']
 
 [tool.coverage.paths]
 source = ["tos", "tos_i18n"]

--- a/tos/__init__.py
+++ b/tos/__init__.py
@@ -1,1 +1,4 @@
-VERSION = (1, 1, 0)
+__version__ = "1.2.0"
+
+# Kept for backwards compatibility with anything importing the tuple form.
+VERSION = tuple(int(part) for part in __version__.split("."))


### PR DESCRIPTION
`tos/__init__.py` still declared `VERSION = (1, 1, 0)` while `pyproject.toml` and PyPI are at **1.2.0** — the `[tool.bumpver.file_patterns]` only rewrote `pyproject.toml`, so the 1.2.0 bump (#102) never touched `__init__.py`.

- Store the version as a bumpver-trackable `__version__ = "1.2.0"` string, and derive `VERSION = (1, 2, 0)` from it (kept for backwards compatibility — nothing else imports it, but downstream code might).
- Add `tos/__init__.py` to `[tool.bumpver.file_patterns]` so future `bumpver` runs keep both in sync.

Verified: `bumpver update --patch --dry` now rewrites both files; `import tos` gives `VERSION == (1, 2, 0)`; lint clean.